### PR TITLE
XSS fix - Remove onload handler from svg element

### DIFF
--- a/apps/editor/src/js/convertor.js
+++ b/apps/editor/src/js/convertor.js
@@ -88,6 +88,22 @@ class Convertor {
   }
 
   /**
+   * Remove 'onload' attribute of svg tag
+   * @param {string} markdown markdown text
+   * @returns {string} replaced markdown text
+   * @private
+   */
+  _removeSvgOnloadProp(markdown) {
+    const onloadStripeRegex = /(<svg[^>]*)(onload\s*=\s*[\\"']?[^\\"']*[\\"']?)(.*)/i;
+
+    while (onloadStripeRegex.exec(markdown)) {
+      markdown = markdown.replace(onloadStripeRegex, '$1$3');
+    }
+
+    return markdown;
+  }
+
+  /**
    * Remove BR's data-tomark-pass attribute text when br in code element
    * @param {string} renderedHTML Rendered HTML string from markdown editor
    * @returns {string}
@@ -143,7 +159,7 @@ class Convertor {
 
   initHtmlSanitizer() {
     this.eventManager.listen('convertorAfterMarkdownToHtmlConverted', html =>
-      htmlSanitizer(html, true)
+      htmlSanitizer(this._removeSvgOnloadProp(html), true)
     );
   }
 


### PR DESCRIPTION
### 📊 Metadata *

`tui.editor` is vulnerable to `Cross-Site Scripting (XSS)`.

#### Bounty URL: https://www.huntr.dev/bounties/1-other-tui.editor/

### ⚙️ Description *

TOAST UI Editor provides Markdown mode and WYSIWYG mode. Depending on the type of use you want like production of Markdown or maybe to just edit the Markdown. The TOAST UI Editor can be helpful for both the usage. It offers Markdown mode and WYSIWYG mode, which can be switched any point in time.

### 💻 Technical Description *

Fixed `XSS` by sanitizing user inputs before updating DOM elements, in this an edge case was arisen due to an `onload` event handler not properly sanitized/removed while updating the DOM elements in the editor.

### 🐛 Proof of Concept (PoC) *

1. Open https://nhn.github.io/tui.editor/latest/tutorial-example01-editor-basic
2. Insert the xss payload in editor Ex: `<svg> <svg><svg onload=alert(111)> <svg>`
3. XSS payload will get executed.

### 🔥 Proof of Fix (PoF) *

// index.html
![image](https://user-images.githubusercontent.com/64132745/108257707-2f1dc000-7185-11eb-8e52-8ece420eefaf.png)

// script.js
```
const editor = new toastui.Editor({
  el: document.querySelector('#editor')
});
```

output:
![image](https://user-images.githubusercontent.com/64132745/108257926-7c9a2d00-7185-11eb-97b7-1136f752ad6e.png)

### 👍 User Acceptance Testing (UAT)

After the fix, functionality is unaffected.

### 🔗 Relates to...

https://github.com/418sec/huntr/pull/1911
